### PR TITLE
Support json configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ var loggerConfig = new LoggerConfiguration()
           Port = 12201
       });
 ```
+...or alternatively configure the sink in appsettings.json configuration like so:
+
+```json
+{
+  "Serilog": {
+    "Using": ["Serilog.Sinks.Graylog"],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+        "Name": "Graylog",
+        "Args": {
+            "hostNameOrAddress": "localhost",
+            "port": "12201",
+            "transportType": "Udp"
+        }
+    ]
+  }
+}
+```
+
+Note that because of the limitations of the Serilog.Settings.Configuration package, you cannot configure IGelfConverter using json. 
 
 by default udp protocol is using, if you want to use http define sink options like 
 

--- a/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Serilog.Events;
+using Serilog.Sinks.Graylog.Transport;
 using Xunit;
 
 namespace Serilog.Sinks.Graylog.Tests
@@ -18,6 +19,18 @@ namespace Serilog.Sinks.Graylog.Tests
                 HostnameOrAdress = "localhost",
                 Port = 12201
             });
+
+            var logger = loggerConfig.CreateLogger();
+            logger.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void CanApplyExtensionWithIntegralParameterTypes()
+        {
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig.WriteTo.Graylog("localhost", 12201, TransportType.Udp,
+                LogEventLevel.Information);
 
             var logger = loggerConfig.CreateLogger();
             logger.Should().NotBeNull();

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -11,17 +11,18 @@ namespace Serilog.Sinks.Graylog
     {
         internal const string DefaultFacility = "GELF";
         internal const int DefaultShortMessageMaxLength = 500;
+        internal const LogEventLevel DefaultMinimumLogEventLevel = LevelAlias.Minimum;
         internal const int DefaultStackTraceDepth = 10;
         internal const MessageIdGeneratortype DefaultMessageGeneratorType = MessageIdGeneratortype.Timestamp;
 
         public GraylogSinkOptions()
         {
             MessageGeneratorType = MessageIdGeneratortype.Timestamp;
-            ShortMessageMaxLength = 500;
-            MinimumLogEventLevel = LevelAlias.Minimum;
+            ShortMessageMaxLength = DefaultShortMessageMaxLength;
+            MinimumLogEventLevel = DefaultMinimumLogEventLevel;
             //Spec says: facility must be set by the client to "GELF" if empty
-            Facility = "GELF";
-            StackTraceDepth = 10;
+            Facility = DefaultFacility;
+            StackTraceDepth = DefaultStackTraceDepth;
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -9,6 +9,11 @@ namespace Serilog.Sinks.Graylog
     /// </summary>
     public class GraylogSinkOptions
     {
+        internal const string DefaultFacility = "GELF";
+        internal const int DefaultShortMessageMaxLength = 500;
+        internal const int DefaultStackTraceDepth = 10;
+        internal const MessageIdGeneratortype DefaultMessageGeneratorType = MessageIdGeneratortype.Timestamp;
+
         public GraylogSinkOptions()
         {
             MessageGeneratorType = MessageIdGeneratortype.Timestamp;

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -21,8 +21,8 @@ namespace Serilog.Sinks.Graylog
             TransportType transportType,
             LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
             MessageIdGeneratortype messageIdGeneratorType = GraylogSinkOptions.DefaultMessageGeneratorType,
-            int shortMessageMaxLength = 500,
-            int stackTraceDepth = 10,
+            int shortMessageMaxLength = GraylogSinkOptions.DefaultShortMessageMaxLength,
+            int stackTraceDepth = GraylogSinkOptions.DefaultStackTraceDepth,
             string facility = GraylogSinkOptions.DefaultFacility
             )
         {

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -1,5 +1,8 @@
 ﻿using Serilog.Configuration;
 using Serilog.Core;
+using Serilog.Events;
+using Serilog.Sinks.Graylog.Helpers;
+using Serilog.Sinks.Graylog.Transport;
 
 namespace Serilog.Sinks.Graylog
 {
@@ -10,6 +13,32 @@ namespace Serilog.Sinks.Graylog
         {
             var sink = (ILogEventSink) new GraylogSink(options);
             return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel);
+        }
+
+        public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
+            string hostnameOrAddress,
+            int port,
+            TransportType transportType,
+            LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
+            MessageIdGeneratortype messageIdGeneratorType = GraylogSinkOptions.DefaultMessageGeneratorType,
+            int shortMessageMaxLength = 500,
+            int stackTraceDepth = 10,
+            string facility = GraylogSinkOptions.DefaultFacility
+            )
+        {
+            var options = new GraylogSinkOptions
+            {
+                HostnameOrAdress = hostnameOrAddress,
+                Port = port,
+                TransportType = transportType,
+                MinimumLogEventLevel = minimumLogEventLevel,
+                MessageGeneratorType = messageIdGeneratorType,
+                ShortMessageMaxLength = shortMessageMaxLength,
+                StackTraceDepth = stackTraceDepth,
+                Facility = facility
+            };
+
+            return loggerSinkConfiguration.Graylog(options);
         }
     }
 }


### PR DESCRIPTION
For multi-environment deployment scenarios, it is nice to be able to configure Serilog in json to apply transformations. This is done using the Serilog.Configuration.Settings package. Currently, the package only supports extension methods that accept simple types (string, int, enums). The current extension method accepts the GraylogSinkOptions type, which the configuration framework cannot infer.

This work simply adds an extension method that has simple parameters. The GraylogSinkOptions instance is built and passed to the original method. Updated the readme and added a unit test.