### PR TITLE
GELF 1.1 - timestamp should be unix epoch

### DIFF
--- a/src/Serilog.Sinks.Graylog/GelfMessage.cs
+++ b/src/Serilog.Sinks.Graylog/GelfMessage.cs
@@ -22,7 +22,7 @@ namespace Serilog.Sinks.Graylog
         public string ShortMessage { get; set; }
 
         [JsonProperty("timestamp")]
-        public DateTime Timestamp { get; set; }
+        public double Timestamp { get; set; }
 
         [JsonProperty("version")]
         public string Version { get; set; }

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
@@ -11,6 +11,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
 {
     public class GelfMessageBuilder : IMessageBuilder
     {
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         private readonly string _hostName;
         private const string GelfVersion = "1.1";
         protected GraylogSinkOptions Options { get; }
@@ -32,7 +33,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
                 Host = _hostName,
                 ShortMessage = shortMessage,
                 FullMessage = message,
-                Timestamp = logEvent.Timestamp.DateTime,
+                Timestamp = ConvertToEpoch(logEvent.Timestamp.DateTime),
                 Level = LogLevelMapper.GetMappedLevel(logEvent.Level),
                 StringLevel = logEvent.Level.ToString(),
                 Facility = Options.Facility
@@ -45,6 +46,12 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
             }
 
             return jsonObject;
+        }
+
+        private static double ConvertToEpoch(DateTime dateTime)
+        {
+            var duration = dateTime.ToUniversalTime() - Epoch;
+            return Math.Round(duration.TotalSeconds, 3, MidpointRounding.AwayFromZero);
         }
 
         private void AddAdditionalField(IDictionary<string, JToken> jObject, KeyValuePair<string, LogEventPropertyValue> property, string memberPath = "")


### PR DESCRIPTION
Fix timestampe to not violate GELF.

This fixes the following WARNINGS in Graylog 2.3.

```
2017-08-15 20:26:34,685 WARN : org.graylog2.inputs.codecs.GelfCodec - GELF message <0828bed0-81f8-11e7-87ca-02420aff000e> (received from <10.255.0.17:53463>) has invalid "timestamp": 2017-08-15T16:26:34.571892  (type: STRING)
```