### PR TITLE
Add property naming strategy for field name normalization.

### DIFF
--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -1,5 +1,6 @@
 ﻿using Serilog.Events;
 using Serilog.Sinks.Graylog.Helpers;
+using Serilog.Sinks.Graylog.MessageBuilders;
 using Serilog.Sinks.Graylog.Transport;
 
 namespace Serilog.Sinks.Graylog
@@ -14,6 +15,8 @@ namespace Serilog.Sinks.Graylog
         internal const LogEventLevel DefaultMinimumLogEventLevel = LevelAlias.Minimum;
         internal const int DefaultStackTraceDepth = 10;
         internal const MessageIdGeneratortype DefaultMessageGeneratorType = MessageIdGeneratortype.Timestamp;
+        internal readonly static IPropertyNamingStrategy DefaultPropertyNamingStrategy =
+            new NoOpPropertyNamingStrategy();
 
         public GraylogSinkOptions()
         {
@@ -23,6 +26,7 @@ namespace Serilog.Sinks.Graylog
             //Spec says: facility must be set by the client to "GELF" if empty
             Facility = DefaultFacility;
             StackTraceDepth = DefaultStackTraceDepth;
+            PropertyNamingStrategy = DefaultPropertyNamingStrategy;
         }
 
         /// <summary>
@@ -67,6 +71,7 @@ namespace Serilog.Sinks.Graylog
         /// You can implement another one or use default udp transport
         /// </remarks>
         public TransportType TransportType { get; set; }
+
         /// <summary>
         /// Gets or sets the gelf converter.
         /// </summary>
@@ -77,6 +82,17 @@ namespace Serilog.Sinks.Graylog
         /// You can implement another one for customize fields or use default
         /// </remarks>
         public IGelfConverter GelfConverter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Property Naming Strategy converter.
+        /// </summary>
+        /// <value>
+        /// The Property Naming Strategy.
+        /// </value>
+        /// <remarks>
+        /// You can implement another one for property name normalization
+        /// </remarks>
+        public IPropertyNamingStrategy PropertyNamingStrategy { get; set; }
 
         /// <summary>
         /// Gets or sets the maximal length of the ShortMessage

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -2,6 +2,7 @@
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Sinks.Graylog.Helpers;
+using Serilog.Sinks.Graylog.MessageBuilders;
 using Serilog.Sinks.Graylog.Transport;
 
 namespace Serilog.Sinks.Graylog
@@ -11,7 +12,7 @@ namespace Serilog.Sinks.Graylog
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
             GraylogSinkOptions options)
         {
-            var sink = (ILogEventSink) new GraylogSink(options);
+            var sink = (ILogEventSink)new GraylogSink(options);
             return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel);
         }
 
@@ -23,7 +24,8 @@ namespace Serilog.Sinks.Graylog
             MessageIdGeneratortype messageIdGeneratorType = GraylogSinkOptions.DefaultMessageGeneratorType,
             int shortMessageMaxLength = GraylogSinkOptions.DefaultShortMessageMaxLength,
             int stackTraceDepth = GraylogSinkOptions.DefaultStackTraceDepth,
-            string facility = GraylogSinkOptions.DefaultFacility
+            string facility = GraylogSinkOptions.DefaultFacility,
+            IPropertyNamingStrategy propertyNamingStrategy = null
             )
         {
             var options = new GraylogSinkOptions
@@ -35,7 +37,9 @@ namespace Serilog.Sinks.Graylog
                 MessageGeneratorType = messageIdGeneratorType,
                 ShortMessageMaxLength = shortMessageMaxLength,
                 StackTraceDepth = stackTraceDepth,
-                Facility = facility
+                Facility = facility,
+                PropertyNamingStrategy = propertyNamingStrategy ??
+                    GraylogSinkOptions.DefaultPropertyNamingStrategy
             };
 
             return loggerSinkConfiguration.Graylog(options);

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/CamelCasePropertyNamingStrategy.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/CamelCasePropertyNamingStrategy.cs
@@ -1,0 +1,41 @@
+﻿namespace Serilog.Sinks.Graylog.MessageBuilders
+{
+    public class CamelCasePropertyNamingStrategy : IPropertyNamingStrategy
+    {
+        public string GetPropertyName(string property)
+        {
+            var camelCased = ToCamelCase(property);
+            return camelCased;
+        }
+
+        private static string ToCamelCase(string s)
+        {
+            if (string.IsNullOrEmpty(s) || !char.IsUpper(s[0]))
+            {
+                return s;
+            }
+
+            char[] chars = s.ToCharArray();
+
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (i == 1 && !char.IsUpper(chars[i]))
+                {
+                    break;
+                }
+
+                bool hasNext = (i + 1 < chars.Length);
+                if (i > 0 && hasNext && !char.IsUpper(chars[i + 1]))
+                {
+                    break;
+                }
+
+                char c;
+                c = char.ToLowerInvariant(chars[i]);
+                chars[i] = c;
+            }
+
+            return new string(chars);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/IPropertyNamingStrategy.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/IPropertyNamingStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace Serilog.Sinks.Graylog.MessageBuilders
+{
+    public interface IPropertyNamingStrategy
+    {
+        string GetPropertyName(string property);
+    }
+}

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/NoOpPropertyNamingStrategy.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/NoOpPropertyNamingStrategy.cs
@@ -1,0 +1,10 @@
+﻿namespace Serilog.Sinks.Graylog.MessageBuilders
+{
+    public class NoOpPropertyNamingStrategy : IPropertyNamingStrategy
+    {
+        public string GetPropertyName(string property)
+        {
+            return property;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
+++ b/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PackageId>Serilog.Sinks.Graylog</PackageId>
     <Title>Serilog.Sinks.Graylog</Title>
-    <PackageVersion>1.5.3</PackageVersion>
+    <PackageVersion>1.5.4</PackageVersion>
     <Authors>Anton Volkov</Authors>
     <Description>The Serilog Graylog Sink project is a sink (basically a writer) for the Serilog logging framework. Structured log events are written to sinks and each sink is responsible for writing it to its own backend, database, store etc. This sink delivers the data to Graylog2, a NoSQL search engine.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -27,9 +27,9 @@
     <OutputType>library</OutputType>
     <NeutralLanguage>en</NeutralLanguage>
     <RepositoryType>git</RepositoryType>
-    <Version>1.5.3</Version>
-    <AssemblyVersion>1.5.3.0</AssemblyVersion>
-    <FileVersion>1.5.3.0</FileVersion>
+    <Version>1.5.4</Version>
+    <AssemblyVersion>1.5.4.0</AssemblyVersion>
+    <FileVersion>1.5.4.0</FileVersion>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
@whir1 Apologies for the churn, as the last PR did not solve the problem at hand (normalizing field names in Graylog/ES). The last PR allowed a user to change the Newtonsoft Contract resolver, which, as it turns out, doesn't fire its naming strategy on additional fields added to a JToken. My apologies for the noise, this solution should do the trick.