### PR TITLE
Prop Naming Strategy Fix & Error Propagation Fix

### DIFF
--- a/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Text;
 using Ploeh.AutoFixture;
 using Serilog.Events;
 using Xunit;
-using Serilog.Sinks;
 using Serilog.Sinks.Graylog.Helpers;
 using Serilog.Sinks.Graylog.Tests.ComplexIntegrationTest;
 using Serilog.Sinks.Graylog.Transport;
@@ -26,7 +24,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 TransportType = TransportType.Http,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "http://logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var logger = loggerConfig.CreateLogger();
@@ -65,7 +63,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 TransportType = TransportType.Http,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "http://logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var logger = loggerConfig.CreateLogger();
@@ -86,7 +84,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 TransportType = TransportType.Http,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "http://logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var test = new TestClass

--- a/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithUdp.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithUdp.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Text;
 using Ploeh.AutoFixture;
 using Serilog.Events;
 using Xunit;
-using Serilog.Sinks;
 using Serilog.Sinks.Graylog.Helpers;
 using Serilog.Sinks.Graylog.Tests.ComplexIntegrationTest;
 using Serilog.Sinks.Graylog.Transport;
@@ -26,7 +24,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 MinimumLogEventLevel = LogEventLevel.Information,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var logger = loggerConfig.CreateLogger();
@@ -68,7 +66,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 MessageGeneratorType = MessageIdGeneratortype.Timestamp,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var logger = loggerConfig.CreateLogger();
@@ -89,7 +87,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 TransportType = TransportType.Udp,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "logs.aeroclub.int",
-                Port = 12201
+                Port = 12201,
             });
 
             var test = new TestClass

--- a/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Graylog.Tests
                 MinimumLogEventLevel = LogEventLevel.Information,
                 Facility = "VolkovTestFacility",
                 HostnameOrAddress = "localhost",
-                Port = 12201
+                Port = 12201,
             });
 
             var logger = loggerConfig.CreateLogger();

--- a/src/Serilog.Sinks.Graylog.Tests/MessageBuilders/MessageBuilderFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/MessageBuilders/MessageBuilderFixture.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using Newtonsoft.Json;
 using Serilog.Events;
 using Serilog.Parsing;
@@ -23,9 +22,9 @@ namespace Serilog.Sinks.Graylog.Tests.MessageBuilders
             {
                 facility = "GELF",
                 full_message = "abcdef\"zxc\"",
-                host= "localhost",
+                host = "localhost",
                 level = 2,
-                short_message= "abcdef\"zxc\"",
+                short_message = "abcdef\"zxc\"",
                 timestamp = date.DateTime,
                 version = "1.1",
                 _stringLevel = "Information",

--- a/src/Serilog.Sinks.Graylog.Tests/MessageBuilders/PropertyNamingFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/MessageBuilders/PropertyNamingFixture.cs
@@ -1,0 +1,87 @@
+﻿using Serilog.Events;
+using Serilog.Parsing;
+using Serilog.Sinks.Graylog.MessageBuilders;
+using Serilog.Sinks.Graylog.MessageBuilders.PropertyNaming;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Serilog.Sinks.Graylog.Tests.MessageBuilders
+{
+    public class PropertyNamingFixture
+    {
+        [Fact]
+        public void WhenCamelCasingPropertyNames_ShouldCamelCase()
+        {
+            var sut = new CamelCasePropertyNamingStrategy();
+            Assert.Equal("longPropertyName", sut.GetPropertyName("LongPropertyName"));
+            Assert.Equal("short", sut.GetPropertyName("Short"));
+        }
+
+        [Fact]
+        public void WhenNoOpPropertyNames_ShouldIgnore()
+        {
+            var sut = new NoOpPropertyNamingStrategy();
+            Assert.Equal("LongPropertyName", sut.GetPropertyName("LongPropertyName"));
+            Assert.Equal("Short", sut.GetPropertyName("Short"));
+        }
+
+        [Fact]
+        public void WhenMessageBuilding_ShouldCamelCasePropertyNames()
+        {
+            var sut = new GelfMessageBuilder("localhost", new GraylogSinkOptions
+            {
+                PropertyNamingStrategy = new CamelCasePropertyNamingStrategy(),
+            });
+
+            var @event = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+            new MessageTemplate("abcdef{TestProp}", new List<MessageTemplateToken>
+            {
+                new TextToken("abcdef", 0),
+                new PropertyToken("LongPropertyName", "zxc", alignment:new Alignment(AlignmentDirection.Left, 3)),
+                new PropertyToken("Short", "zxc", alignment:new Alignment(AlignmentDirection.Left, 3))
+
+            }), new List<LogEventProperty>
+            {
+                new LogEventProperty("LongPropertyName", new ScalarValue("zxc")),
+                new LogEventProperty("Short", new ScalarValue("zxc")),
+                new LogEventProperty("id", new ScalarValue("asd"))
+            });
+
+            var actual = sut.Build(@event);
+            Assert.Null(actual.Property("_LongPropertyName"));
+            Assert.Null(actual.Property("_Short"));
+            Assert.NotNull(actual.Property("_longPropertyName"));
+            Assert.NotNull(actual.Property("_short"));
+        }
+
+        [Fact]
+        public void WhenMessageBuilding_ShouldIgnorePropertyNames()
+        {
+            var sut = new GelfMessageBuilder("localhost", new GraylogSinkOptions
+            {
+                PropertyNamingStrategy = new NoOpPropertyNamingStrategy(),
+            });
+
+            var @event = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, null,
+            new MessageTemplate("abcdef{TestProp}", new List<MessageTemplateToken>
+            {
+                new TextToken("abcdef", 0),
+                new PropertyToken("LongPropertyName", "zxc", alignment:new Alignment(AlignmentDirection.Left, 3)),
+                new PropertyToken("Short", "zxc", alignment:new Alignment(AlignmentDirection.Left, 3))
+
+            }), new List<LogEventProperty>
+            {
+                new LogEventProperty("LongPropertyName", new ScalarValue("zxc")),
+                new LogEventProperty("Short", new ScalarValue("zxc")),
+                new LogEventProperty("id", new ScalarValue("asd"))
+            });
+
+            var actual = sut.Build(@event);
+            Assert.Null(actual.Property("_longPropertyName"));
+            Assert.Null(actual.Property("_short"));
+            Assert.NotNull(actual.Property("_LongPropertyName"));
+            Assert.NotNull(actual.Property("_Short"));
+        }
+    }
+}

--- a/src/Serilog.Sinks.Graylog.Tests/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/Serilog.Sinks.Graylog.Tests/Serilog.Sinks.Graylog.Tests.csproj
+++ b/src/Serilog.Sinks.Graylog.Tests/Serilog.Sinks.Graylog.Tests.csproj
@@ -15,13 +15,13 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.2.*" />
+    <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.2.*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.*" />
-    <PackageReference Include="AutoFixture" Version="3.50.2" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Moq" Version="4.7.1" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="AutoFixture" Version="3.51.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Moq" Version="4.7.145" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Serilog.Sinks.Graylog\Serilog.Sinks.Graylog.csproj" />

--- a/src/Serilog.Sinks.Graylog/GelfConverterFactory.cs
+++ b/src/Serilog.Sinks.Graylog/GelfConverterFactory.cs
@@ -1,0 +1,24 @@
+﻿using Serilog.Sinks.Graylog.MessageBuilders;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace Serilog.Sinks.Graylog
+{
+    public static class GelfConverterFactory
+    {
+        public static Func<IGelfConverter> FromOptions(GraylogSinkOptions options) => () =>
+        {
+            var hostName = Dns.GetHostName();
+            var builders = new Dictionary<BuilderType, Lazy<IMessageBuilder>>
+            {
+                [BuilderType.Exception] =
+                new Lazy<IMessageBuilder>(() => new ExceptionMessageBuilder(hostName, options)),
+                [BuilderType.Message] =
+                new Lazy<IMessageBuilder>(() => new GelfMessageBuilder(hostName, options))
+            };
+
+            return new GelfConverter(builders);
+        };
+    }
+}

--- a/src/Serilog.Sinks.Graylog/GelfMessage.cs
+++ b/src/Serilog.Sinks.Graylog/GelfMessage.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 
 namespace Serilog.Sinks.Graylog
 {

--- a/src/Serilog.Sinks.Graylog/GraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSink.cs
@@ -4,20 +4,20 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.Graylog.Transport;
-
+using Serilog.Sinks.Graylog.Helpers;
 
 namespace Serilog.Sinks.Graylog
 {
     public class GraylogSink : ILogEventSink
     {
         private readonly IGelfConverter _converter;
-        private readonly Lazy<ITransport> _transport;
+        private readonly LazyRetry<ITransport> _transport;
         private readonly GraylogSinkOptions options;
 
         public GraylogSink(GraylogSinkOptions graylogSinkOptions, Func<ITransport> transportFactory = null)
         {
             options = graylogSinkOptions ?? new GraylogSinkOptions();
-            _transport = new Lazy<ITransport>(transportFactory ?? TransportFactory.FromOptions(options));
+            _transport = new LazyRetry<ITransport>(transportFactory ?? TransportFactory.FromOptions(options));
             _converter = options.GelfConverter ?? GelfConverterFactory.FromOptions(options).Invoke();
         }
 

--- a/src/Serilog.Sinks.Graylog/GraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSink.cs
@@ -83,7 +83,6 @@ namespace Serilog.Sinks.Graylog
             catch (Exception e)
             {
                 SelfLog.WriteLine("Exception while emitting from {0}: {1}", this, e);
-                if (options.ThrowInternalErrors) throw;
             }
         }
     }

--- a/src/Serilog.Sinks.Graylog/GraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSink.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.Graylog.Helpers;
 using Serilog.Sinks.Graylog.MessageBuilders;
@@ -21,34 +21,46 @@ namespace Serilog.Sinks.Graylog
     {
         private readonly IGelfConverter _converter;
         private readonly ITransport _transport;
+        private readonly GraylogSinkOptions options;
 
-        public GraylogSink(GraylogSinkOptions options)
+        public GraylogSink(GraylogSinkOptions graylogSinkOptions)
         {
-            _transport = MakeTransport(options);
-
-            string hostName = Dns.GetHostName();
-
-            IDictionary<BuilderType, Lazy<IMessageBuilder>> builders = new Dictionary<BuilderType, Lazy<IMessageBuilder>>
+            try
             {
-                [BuilderType.Exception] = new Lazy<IMessageBuilder>(() => new ExceptionMessageBuilder(hostName, options)),
-                [BuilderType.Message] = new Lazy<IMessageBuilder>(() => new GelfMessageBuilder(hostName, options))
-            };
-              
-            _converter = options.GelfConverter ?? new GelfConverter(builders);
+                options = graylogSinkOptions ?? new GraylogSinkOptions();
+                _transport = MakeTransport(options);
+
+                var hostName = Dns.GetHostName();
+                var builders =
+                    new Dictionary<BuilderType, Lazy<IMessageBuilder>>
+                    {
+                        [BuilderType.Exception] =
+                        new Lazy<IMessageBuilder>(() => new ExceptionMessageBuilder(hostName, options)),
+                        [BuilderType.Message] =
+                        new Lazy<IMessageBuilder>(() => new GelfMessageBuilder(hostName, options))
+                    };
+
+                _converter = options.GelfConverter ?? new GelfConverter(builders);
+            }
+            catch (Exception e)
+            {
+                SelfLog.WriteLine($"Unhandled initialization exception -> {e}");
+                if (options.ThrowInternalErrors) throw;
+            }
         }
 
-        private ITransport MakeTransport(GraylogSinkOptions options)
+        private static ITransport MakeTransport(GraylogSinkOptions options)
         {
             switch (options.TransportType)
             {
                 case SerilogTransportType.Udp:
 
-                    IDnsInfoProvider dns = new DnsWrapper();
-                    IPAddress[] ipAddreses = Task.Run(() => dns.GetHostAddresses(options.HostnameOrAddress)).Result;
-                    IPAddress ipAddress = ipAddreses.FirstOrDefault(c => c.AddressFamily == AddressFamily.InterNetwork);
+                    var dns = new DnsWrapper();
+                    var ipAddreses = Task.Run(() => dns.GetHostAddresses(options.HostnameOrAddress)).Result;
+                    var ipAddress = ipAddreses.FirstOrDefault(c => c.AddressFamily == AddressFamily.InterNetwork);
                     var ipEndpoint = new IPEndPoint(ipAddress, options.Port);
 
-                    IDataToChunkConverter chunkConverter = new DataToChunkConverter(new ChunkSettings
+                    var chunkConverter = new DataToChunkConverter(new ChunkSettings
                     {
                         MessageIdGeneratorType = options.MessageGeneratorType
                     }, new MessageIdGeneratorResolver());
@@ -63,14 +75,22 @@ namespace Serilog.Sinks.Graylog
                 default:
                     throw new ArgumentOutOfRangeException(nameof(options), options.TransportType, null);
             }
-            
         }
 
         public void Emit(LogEvent logEvent)
         {
-            JObject json = _converter.GetGelfJson(logEvent);
-
-            Task.Factory.StartNew(async () => await _transport.Send(json.ToString(Newtonsoft.Json.Formatting.None)).ConfigureAwait(false)).GetAwaiter().GetResult();
+            try
+            {
+                var jObject = _converter.GetGelfJson(logEvent);
+                var json = jObject.ToString(Newtonsoft.Json.Formatting.None);
+                Task.Run(async () => await _transport.Send(json).ConfigureAwait(false))
+                    .GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                SelfLog.WriteLine($"Unhandled emit exception -> {e}");
+                if (options.ThrowInternalErrors) throw;
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -135,7 +135,7 @@ namespace Serilog.Sinks.Graylog
         public IPropertyNamingStrategy PropertyNamingStrategy { get; set; }
 
         /// <summary>
-        /// Indicates of the Sink should propogate send errors.
+        /// Indicates if the Sink should propogate send errors.
         /// </summary>
         /// <value>
         /// True if errors should be rethrown and propogated up.

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -29,6 +29,7 @@ namespace Serilog.Sinks.Graylog
             Facility = DefaultFacility;
             StackTraceDepth = DefaultStackTraceDepth;
             PropertyNamingStrategy = DefaultPropertyNamingStrategy;
+            ThrowOnSendError = true;
         }
 
         /// <summary>
@@ -132,5 +133,13 @@ namespace Serilog.Sinks.Graylog
         /// The property naming strategy.
         /// </value>
         public IPropertyNamingStrategy PropertyNamingStrategy { get; set; }
+
+        /// <summary>
+        /// Indicates of the Sink should propogate send errors.
+        /// </summary>
+        /// <value>
+        /// True if errors should be rethrown and propogated up.
+        /// 
+        public bool ThrowOnSendError { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -16,7 +16,9 @@ namespace Serilog.Sinks.Graylog
         internal const LogEventLevel DefaultMinimumLogEventLevel = LevelAlias.Minimum;
         internal const int DefaultStackTraceDepth = 10;
         internal const MessageIdGeneratortype DefaultMessageGeneratorType = MessageIdGeneratortype.Timestamp;
-        internal static readonly IPropertyNamingStrategy DefaultPropertyNamingStrategy = new NoOpPropertyNamingStrategy();
+
+        internal static readonly IPropertyNamingStrategy DefaultPropertyNamingStrategy =
+            new NoOpPropertyNamingStrategy();
 
         public GraylogSinkOptions()
         {
@@ -84,6 +86,7 @@ namespace Serilog.Sinks.Graylog
         /// You can implement another one or use default udp transport
         /// </remarks>
         public TransportType TransportType { get; set; }
+
         /// <summary>
         /// Gets or sets the gelf converter.
         /// </summary>
@@ -129,5 +132,7 @@ namespace Serilog.Sinks.Graylog
         /// The property naming strategy.
         /// </value>
         public IPropertyNamingStrategy PropertyNamingStrategy { get; set; }
+
+        public bool ThrowInternalErrors { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSinkOptions.cs
@@ -132,7 +132,5 @@ namespace Serilog.Sinks.Graylog
         /// The property naming strategy.
         /// </value>
         public IPropertyNamingStrategy PropertyNamingStrategy { get; set; }
-
-        public bool ThrowInternalErrors { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog/Helpers/LazyRetry.cs
+++ b/src/Serilog.Sinks.Graylog/Helpers/LazyRetry.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Serilog.Sinks.Graylog.Helpers
+{
+    public class LazyRetry<T>
+    {
+        private readonly Func<T> _valueFactory;
+        private Lazy<T> _lazy;
+
+        public LazyRetry(Func<T> valueFactory)
+        {
+            _valueFactory = valueFactory;
+            _lazy = new Lazy<T>(valueFactory);
+        }
+
+        public T Value
+        {
+            get
+            {
+                try
+                {
+                    return _lazy.Value;
+                }
+                catch (Exception)
+                {
+                    _lazy = new Lazy<T>(_valueFactory);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Serilog.Sinks.Graylog/Helpers/LogLevelMapper.cs
+++ b/src/Serilog.Sinks.Graylog/Helpers/LogLevelMapper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Serilog.Events;
 
 namespace Serilog.Sinks.Graylog.Helpers

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using Serilog.Sinks.Graylog.Helpers;
 using Serilog.Sinks.Graylog.MessageBuilders.PropertyNaming;
 using Serilog.Sinks.Graylog.Transport;
+using System;
 
 namespace Serilog.Sinks.Graylog
 {
@@ -19,7 +20,7 @@ namespace Serilog.Sinks.Graylog
             GraylogSinkOptions options
         )
         {
-            var sink = (ILogEventSink) new GraylogSink(options);
+            var sink = (ILogEventSink)new GraylogSink(options);
             return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel);
         }
 

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -16,7 +16,8 @@ namespace Serilog.Sinks.Graylog
         /// <param name="options">The options.</param>
         /// <returns></returns>
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
-            GraylogSinkOptions options)
+            GraylogSinkOptions options
+        )
         {
             var sink = (ILogEventSink) new GraylogSink(options);
             return loggerSinkConfiguration.Sink(sink, options.MinimumLogEventLevel);
@@ -36,14 +37,14 @@ namespace Serilog.Sinks.Graylog
         /// <param name="facility">The facility.</param>
         /// <returns></returns>
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
-                                                  string hostnameOrAddress,
-                                                  int port,
-                                                  TransportType transportType,
-                                                  LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
-                                                  MessageIdGeneratortype messageIdGeneratorType = GraylogSinkOptions.DefaultMessageGeneratorType,
-                                                  int shortMessageMaxLength = GraylogSinkOptions.DefaultShortMessageMaxLength,
-                                                  int stackTraceDepth = GraylogSinkOptions.DefaultStackTraceDepth,
-                                                  string facility = GraylogSinkOptions.DefaultFacility)
+            string hostnameOrAddress,
+            int port,
+            TransportType transportType,
+            LogEventLevel minimumLogEventLevel = LevelAlias.Minimum,
+            MessageIdGeneratortype messageIdGeneratorType = GraylogSinkOptions.DefaultMessageGeneratorType,
+            int shortMessageMaxLength = GraylogSinkOptions.DefaultShortMessageMaxLength,
+            int stackTraceDepth = GraylogSinkOptions.DefaultStackTraceDepth,
+            string facility = GraylogSinkOptions.DefaultFacility)
         {
             var options = new GraylogSinkOptions
             {

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 using Serilog.Events;
 using Serilog.Sinks.Graylog.Extensions;
@@ -18,6 +17,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
     {
         private readonly string _hostName;
         private const string GelfVersion = "1.1";
+        private readonly IPropertyNamingStrategy _propertyNamingStrategy;
         protected GraylogSinkOptions Options { get; }
 
         /// <summary>
@@ -27,8 +27,9 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
         /// <param name="options">The options.</param>
         public GelfMessageBuilder(string hostName, GraylogSinkOptions options)
         {
-            _hostName = hostName;
-            Options = options;
+            Options = options ?? throw new ArgumentNullException(nameof(options));
+            _hostName = string.IsNullOrWhiteSpace(hostName) ? "localhost" : hostName;
+            _propertyNamingStrategy = options.PropertyNamingStrategy ?? new NoOpPropertyNamingStrategy();
         }
 
         /// <summary>
@@ -65,9 +66,9 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
 
         private void AddAdditionalField(IDictionary<string, JToken> jObject,
                                         KeyValuePair<string, LogEventPropertyValue> property,
-                                        string memberPath = "" )
+                                        string memberPath = "")
         {
-            var propertyName = Options.PropertyNamingStrategy?.GetPropertyName(property.Key) ?? property.Key;
+            var propertyName = _propertyNamingStrategy.GetPropertyName(property.Key);
             var key = string.IsNullOrWhiteSpace(memberPath)
                 ? propertyName
                 : $"{memberPath}.{propertyName}";
@@ -87,9 +88,9 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
                     }
 
                     var shouldCallToString = SholdCallToString(scalarValue.Value.GetType());
-                
+
                     JToken value = JToken.FromObject(shouldCallToString ? scalarValue.Value.ToString() : scalarValue.Value);
-                
+
                     jObject.Add(key, value);
                     return;
                 case SequenceValue sequenceValue:

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
@@ -27,7 +27,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
         /// <param name="options">The options.</param>
         public GelfMessageBuilder(string hostName, GraylogSinkOptions options)
         {
-            Options = options ?? throw new ArgumentNullException(nameof(options));
+            Options = options ?? new GraylogSinkOptions();
             _hostName = string.IsNullOrWhiteSpace(hostName) ? "localhost" : hostName;
             _propertyNamingStrategy = options.PropertyNamingStrategy ?? new NoOpPropertyNamingStrategy();
         }

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
         /// </summary>
         /// <param name="hostName">Name of the host.</param>
         /// <param name="options">The options.</param>
-        public GelfMessageBuilder(string hostName, GraylogSinkOptions options)
+        public GelfMessageBuilder(string hostName = null, GraylogSinkOptions options = null)
         {
             Options = options ?? new GraylogSinkOptions();
             _hostName = string.IsNullOrWhiteSpace(hostName) ? "localhost" : hostName;

--- a/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog/MessageBuilders/GelfMessageBuilder.cs
@@ -16,9 +16,7 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
     /// <seealso cref="Serilog.Sinks.Graylog.MessageBuilders.IMessageBuilder" />
     public class GelfMessageBuilder : IMessageBuilder
     {
-        
         private readonly string _hostName;
-        private readonly IPropertyNamingStrategy _propertyNamingStrategy;
         private const string GelfVersion = "1.1";
         protected GraylogSinkOptions Options { get; }
 
@@ -31,7 +29,6 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
         {
             _hostName = hostName;
             Options = options;
-            _propertyNamingStrategy = options.PropertyNamingStrategy;
         }
 
         /// <summary>
@@ -70,10 +67,10 @@ namespace Serilog.Sinks.Graylog.MessageBuilders
                                         KeyValuePair<string, LogEventPropertyValue> property,
                                         string memberPath = "" )
         {
-            var propertyName = _propertyNamingStrategy.GetPropertyName(property.Key);
-            string key = string.IsNullOrEmpty(memberPath)
-                ? property.Key
-                : $"{memberPath}.{property.Key}";
+            var propertyName = Options.PropertyNamingStrategy?.GetPropertyName(property.Key) ?? property.Key;
+            var key = string.IsNullOrWhiteSpace(memberPath)
+                ? propertyName
+                : $"{memberPath}.{propertyName}";
 
             switch (property.Value)
             {

--- a/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
+++ b/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackageId>Serilog.Sinks.Graylog</PackageId>
     <Title>Serilog.Sinks.Graylog</Title>
-    <PackageVersion>1.6.0</PackageVersion>
+    <PackageVersion>1.6.1</PackageVersion>
     <Authors>Anton Volkov</Authors>
     <Description>The Serilog Graylog Sink project is a sink (basically a writer) for the Serilog logging framework. Structured log events are written to sinks and each sink is responsible for writing it to its own backend, database, store etc. This sink delivers the data to Graylog2, a NoSQL search engine.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
+++ b/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
@@ -26,9 +26,9 @@
     <OutputType>library</OutputType>
     <NeutralLanguage>en</NeutralLanguage>
     <RepositoryType>git</RepositoryType>
-    <Version>1.6.0</Version>
-    <AssemblyVersion>1.6.0.0</AssemblyVersion>
-    <FileVersion>1.6.0.0</FileVersion>
+    <Version>1.6.1</Version>
+    <AssemblyVersion>1.6.1.0</AssemblyVersion>
+    <FileVersion>1.6.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
+++ b/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
@@ -8,7 +8,6 @@
     <DebugType>full</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors />
-
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>Serilog.Sinks.Graylog</PackageId>
@@ -31,7 +30,6 @@
     <AssemblyVersion>1.6.0.0</AssemblyVersion>
     <FileVersion>1.6.0.0</FileVersion>
   </PropertyGroup>
-  
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />
     <None Remove="*.ncrunchproject" />
@@ -44,7 +42,6 @@
   <ItemGroup Condition="('$(TargetFramework)'=='netstandard1.6') Or ('$(TargetFramework)'=='netstandard2.0')">
     <PackageReference Include="System.Net.NameResolution" Version="4.3.*" />
   </ItemGroup>
-  
   <ItemGroup Condition="('$(TargetFramework)'=='net45') Or ('$(TargetFramework)'=='net46') Or ('$(TargetFramework)'=='net461')">
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />

--- a/src/Serilog.Sinks.Graylog/Transport/DnsResolver.cs
+++ b/src/Serilog.Sinks.Graylog/Transport/DnsResolver.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace Serilog.Sinks.Graylog.Transport

--- a/src/Serilog.Sinks.Graylog/Transport/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog/Transport/TransportFactory.cs
@@ -1,0 +1,52 @@
+﻿using Serilog.Sinks.Graylog.Helpers;
+using Serilog.Sinks.Graylog.Transport.Http;
+using Serilog.Sinks.Graylog.Transport.Udp;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace Serilog.Sinks.Graylog.Transport
+{
+    public static class TransportFactory
+    {
+        public static Func<ITransport> FromOptions(GraylogSinkOptions options)
+        {
+            switch (options.TransportType)
+            {
+                case TransportType.Udp:
+                    return CreateUdpFactory(options);
+                case TransportType.Http:
+                    return CreateHttpFactory(options);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(options), options.TransportType, null);
+            }
+        }
+
+        private static Func<ITransport> CreateHttpFactory(GraylogSinkOptions options) => () =>
+        {
+            var httpClient = new HttpTransportClient($"{options.HostnameOrAddress}:{options.Port}/gelf");
+            var httpTransport = new HttpTransport(httpClient);
+            return httpTransport;
+        };
+
+        private static Func<ITransport> CreateUdpFactory(GraylogSinkOptions options) => () =>
+        {
+            var dns = new DnsWrapper();
+            var ipAddreses = Task.Run(() => dns.GetHostAddresses(options.HostnameOrAddress)).Result;
+            var ipAddress = ipAddreses.FirstOrDefault(c => c.AddressFamily == AddressFamily.InterNetwork);
+            var ipEndpoint = new IPEndPoint(ipAddress, options.Port);
+
+            var chunkConverter = new DataToChunkConverter(new ChunkSettings
+            {
+                MessageIdGeneratorType = options.MessageGeneratorType
+            }, new MessageIdGeneratorResolver());
+
+            var udpClient = new UdpTransportClient(ipEndpoint);
+            var udpTransport = new UdpTransport(udpClient, chunkConverter);
+            return udpTransport;
+        };
+    }
+
+}

--- a/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransport.cs
+++ b/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransport.cs
@@ -28,13 +28,14 @@ namespace Serilog.Sinks.Graylog.Transport.Udp
         /// <param name="message">The message.</param>
         /// <exception cref="System.ArgumentException">message was too long</exception>
         /// <exception cref="ArgumentException">message was too long</exception>
-        public Task Send(string message)
+        public async Task Send(string message)
         {
             byte[] compressedMessage = message.Compress();
             IList<byte[]> chunks = _chunkConverter.ConvertToChunks(compressedMessage);
-
-            var sendTasks = chunks.Select(c => _transportClient.Send(c));
-            return Task.WhenAll(sendTasks.ToArray());
+            foreach (var chunk in chunks)
+            {
+                await _transportClient.Send(chunk);
+            }
         }
     }
 }

--- a/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransport.cs
+++ b/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransport.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog.Sinks.Graylog.Extensions;

--- a/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransportClient.cs
+++ b/src/Serilog.Sinks.Graylog/Transport/Udp/UdpTransportClient.cs
@@ -25,11 +25,11 @@ namespace Serilog.Sinks.Graylog.Transport.Udp
         /// Sends the specified payload.
         /// </summary>
         /// <param name="payload">The payload.</param>
-        public Task Send(byte[] payload)
+        public async Task Send(byte[] payload)
         {
             using (var udpClient = new UdpClient())
             {
-                return udpClient.SendAsync(payload, payload.Length, _target);
+                await udpClient.SendAsync(payload, payload.Length, _target);
             }
         }
     }


### PR DESCRIPTION
Prop naming strategy was broken in the last refactor shuffle. This fixes that issue and adds tests to ensure functionality. 

Error propagation from logging calls was always occurring, causing potential crashes in logging calls not wrapped in try/catch. This fix adds default handling (as done in internal serilog sinks). Additionally, the creation of the ITransport (along with DNS resolution of host) is now deferred until log time to ensure all faults are properly handled. Tests are also added for error handling scenarios.

Final note, if "ThrowOnSendError" is False, and an exception is thrown in lazy loaded initialization of ITransport (ie: DNS resolution fails), a transient exception is thrown, and initialization will be retried on next logging call.