### PR TITLE
Moved transport dispose to after base.Dispose to allow for flush.

### DIFF
--- a/src/Serilog.Sinks.Graylog.Batching/PeriodicBatchingGraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog.Batching/PeriodicBatchingGraylogSink.cs
@@ -66,8 +66,8 @@ namespace Serilog.Sinks.Graylog.Batching
 
         protected override void Dispose(bool disposing)
         {
-            _transport?.Dispose();
             base.Dispose(disposing);
+            _transport?.Dispose();
         }
     }
 }


### PR DESCRIPTION
When stopping my Windows service using the batch sink I call Serilog.Log.CloseAndFlush().  This is consistently giving me the following exception.
```
2018-08-14T18:33:23.5949517Z Exception while emitting periodic batch from Serilog.Sinks.Graylog.Batching.PeriodicBatchingGraylogSink: System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'System.Net.Sockets.UdpClient'.
   at System.Net.Sockets.UdpClient.BeginSend(Byte[] datagram, Int32 bytes, IPEndPoint endPoint, AsyncCallback requestCallback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl[TArg1,TArg2,TArg3](Func`6 beginMethod, Func`2 endFunction, Action`1 endAction, TArg1 arg1, TArg2 arg2, TArg3 arg3, Object state, TaskCreationOptions creationOptions)
   at System.Net.Sockets.UdpClient.SendAsync(Byte[] datagram, Int32 bytes, IPEndPoint endPoint)
   at Serilog.Sinks.Graylog.Core.Transport.Udp.UdpTransportClient.Send(Byte[] payload)
   at Serilog.Sinks.Graylog.Core.Transport.Udp.UdpTransport.<Send>b__3_0(Byte[] c)
   at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Serilog.Sinks.Graylog.Core.Transport.Udp.UdpTransport.Send(String message)
   at Serilog.Sinks.Graylog.Batching.PeriodicBatchingGraylogSink.<EmitBatchAsync>b__6_0(LogEvent logEvent)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Threading.Tasks.Task.WhenAll(IEnumerable`1 tasks)
   at Serilog.Sinks.Graylog.Batching.PeriodicBatchingGraylogSink.EmitBatchAsync(IEnumerable`1 events)
   at Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink.<OnTick>d__16.MoveNext()
```
It looks like the base.Dispose() is attempting to use the transport to send the last log messages when it flushes, and the transport has already been disposed. I ran a local build with this change and it fixes the problem. 