### PR TITLE
Fix increase connections to transport

### DIFF
--- a/src/Serilog.Sinks.Graylog/GraylogSink.cs
+++ b/src/Serilog.Sinks.Graylog/GraylogSink.cs
@@ -9,7 +9,7 @@ using Serilog.Sinks.Graylog.Core.Transport;
 
 namespace Serilog.Sinks.Graylog
 {
-    public class GraylogSink : ILogEventSink
+    public class GraylogSink : ILogEventSink, IDisposable
     {
         private readonly Lazy<IGelfConverter> _converter;
         private readonly Lazy<ITransport> _transport;
@@ -20,6 +20,11 @@ namespace Serilog.Sinks.Graylog
             ISinkComponentsBuilder sinkComponentsBuilder = new SinkComponentsBuilder(options);
             _transport = new Lazy<ITransport>(() => sinkComponentsBuilder.MakeTransport());
             _converter = new Lazy<IGelfConverter>(() => sinkComponentsBuilder.MakeGelfConverter());
+        }
+        
+        public void Dispose()
+        {
+            _transport.Value.Dispose();
         }
 
         public void Emit(LogEvent logEvent)


### PR DESCRIPTION
In our project, we found the problem with increase connections to UDP protocol channel.
After create `Serilog.Core.Logger` instance and send log we dispose this object but UDP connections remain.
We use `Serilog.Core.Logger.Dispose()` for dispose instance and it run function (found in source code):

` 
var disposableSinks = _logEventSinks.Concat(_auditSinks).OfType<IDisposable>().ToArray();
foreach (var disposable in disposableSinks)
{
      disposable.Dispose();
}
`

But `GraylogSink` don't implement interface IDisposable

