### PR TITLE
Added the capability to set output GELF messages' "host" property

### DIFF
--- a/src/Serilog.Sinks.Graylog.Core.Tests/MessageBuilders/MessageBuilderFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Core.Tests/MessageBuilders/MessageBuilderFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.Graylog.Core.MessageBuilders;
@@ -52,6 +53,27 @@ namespace Serilog.Sinks.Graylog.Core.Tests.MessageBuilders
             LogEvent logEvent = LogEventSource.GetComplexEvent(date);
 
             string actual = target.Build(logEvent).ToString(Newtonsoft.Json.Formatting.None);
+        }
+
+        [Fact]
+        public void GetSimpleLogEvent_GraylogSinkOptionsContainsHost_ReturnsOptionsHost()
+        {
+            //arrange
+            GraylogSinkOptions options = new GraylogSinkOptions()
+            {
+                Host = "my_host"
+            };
+            GelfMessageBuilder messageBuilder = new GelfMessageBuilder("localhost", options);
+            DateTime date = DateTime.UtcNow;
+            string expectedHost = "my_host";
+            
+            //act
+            LogEvent logEvent = LogEventSource.GetSimpleLogEvent(date);
+            JObject actual = messageBuilder.Build(logEvent);
+            string actualHost = actual.Value<string>("host");
+
+            //assert
+            Assert.Equal(expectedHost, actualHost);
         }
 
 

--- a/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
@@ -17,6 +17,10 @@ namespace Serilog.Sinks.Graylog.Core
         public const MessageIdGeneratortype DefaultMessageGeneratorType = MessageIdGeneratortype.Timestamp;
 
         public const int DefaultMaxMessageSizeInUdp = 8192;
+        /// <summary>
+        /// The default option value (null) for GELF's "host" property. DNS hostname will be used instead.
+        /// </summary>
+        public const string DefaultHost = null;
 
         // ReSharper disable once PublicConstructorInAbstractClass
         public GraylogSinkOptionsBase()
@@ -28,6 +32,7 @@ namespace Serilog.Sinks.Graylog.Core
             Facility = DefaultFacility;
             StackTraceDepth = DefaultStackTraceDepth;
             MaxMessageSizeInUdp = DefaultMaxMessageSizeInUdp;
+            Host = DefaultHost;
         }
 
         /// <summary>
@@ -118,5 +123,10 @@ namespace Serilog.Sinks.Graylog.Core
         /// The maximum udp message size
         /// </value>
         public int MaxMessageSizeInUdp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the host property required by the GELF format. If set to null, DNS hostname will be used instead.
+        /// </summary>
+        public string Host { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog.Core/MessageBuilders/GelfMessageBuilder.cs
+++ b/src/Serilog.Sinks.Graylog.Core/MessageBuilders/GelfMessageBuilder.cs
@@ -43,7 +43,7 @@ namespace Serilog.Sinks.Graylog.Core.MessageBuilders
             var gelfMessage = new GelfMessage
             {
                 Version = DefaultGelfVersion,
-                Host = _hostName,
+                Host = Options.Host ?? _hostName,
                 ShortMessage = shortMessage,
                 Timestamp = logEvent.Timestamp.ConvertToNix(),
                 Level = LogLevelMapper.GetMappedLevel(logEvent.Level),

--- a/src/Serilog.Sinks.Graylog.Tests/Configurations/AppSettingsWithGraylogSinkContainingHostProperty.json
+++ b/src/Serilog.Sinks.Graylog.Tests/Configurations/AppSettingsWithGraylogSinkContainingHostProperty.json
@@ -1,0 +1,24 @@
+﻿{
+    "Serilog": {
+        "WriteTo": [
+            {
+                "Name": "Console",
+                "Args": {
+                    "restrictedToMinimumLevel": "Information",
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss}] [{Level:u4}] {Message:lj} {NewLine}{Exception}"
+                }
+            },
+            {
+                "Name": "Graylog",
+                "Args": {
+                    "facility": "MicroserviceTemplate.Host.WebApi",
+                    "hostnameOrAddress": "http://localhost",
+                    "port": 12201,
+                    "transportType": "Http",
+                    "host": "my_host",
+                    "outputTemplate": "[{Timestamp:yyyy-MM-dd HH:mm:ss}] [{Level:u4}] {Message:lj} {NewLine}{Exception}"
+                }
+            }
+        ]
+    }
+}

--- a/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/LoggerConfigurationGrayLogExtensionsFixture.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿using System.IO;
+using System.Reflection;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Serilog.Events;
 using Serilog.Sinks.Graylog.Core;
 using Serilog.Sinks.Graylog.Core.Transport;
@@ -36,5 +39,30 @@ namespace Serilog.Sinks.Graylog.Tests
             var logger = loggerConfig.CreateLogger();
             logger.Should().NotBeNull();
         }
+
+
+        //[Fact(Skip="Integration test")]
+        [Fact]
+        public void CanReadHostPropertyConfiguration()
+        {
+            //arrange
+            //
+            IConfigurationRoot configuration;
+            using (Stream s = Assembly.GetExecutingAssembly().GetManifestResourceStream("Serilog.Sinks.Graylog.Tests.Configurations.AppSettingsWithGraylogSinkContainingHostProperty.json"))
+            {
+                configuration = new ConfigurationBuilder()
+                    .AddJsonStream(s)
+                    .Build();
+            }
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration, "Serilog")
+                .CreateLogger();
+
+            //act
+            Log.Information("Hello {ApplicationName}.", "SerilogGraylogSink");
+
+            //assert
+        }
+
     }
 }

--- a/src/Serilog.Sinks.Graylog.Tests/Serilog.Sinks.Graylog.Tests.csproj
+++ b/src/Serilog.Sinks.Graylog.Tests/Serilog.Sinks.Graylog.Tests.csproj
@@ -4,9 +4,17 @@
     <DebugType>full</DebugType>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="Configurations\AppSettingsWithGraylogSinkContainingHostProperty.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Configurations\AppSettingsWithGraylogSinkContainingHostProperty.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="altcover" Version="5.3.679" />
     <PackageReference Include="Serilog.Exceptions" Version="5.3.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
 
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
     <PackageReference Include="AutoFixture" Version="4.11.0" />

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -37,6 +37,7 @@ namespace Serilog.Sinks.Graylog
         /// <param name="stackTraceDepth">The stack trace depth.</param>
         /// <param name="facility">The facility.</param>
         /// <param name="maxMessageSizeInUdp">the maxMessageSizeInUdp</param>
+        /// <param name="host">The host property to use in GELF message. If null, DNS hostname will be used instead.</param>
         /// <returns></returns>
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
                                                   string hostnameOrAddress,
@@ -47,7 +48,8 @@ namespace Serilog.Sinks.Graylog
                                                   int shortMessageMaxLength = GraylogSinkOptionsBase.DefaultShortMessageMaxLength,
                                                   int stackTraceDepth = GraylogSinkOptionsBase.DefaultStackTraceDepth,
                                                   string facility = GraylogSinkOptionsBase.DefaultFacility,
-                                                  int maxMessageSizeInUdp = GraylogSinkOptionsBase.DefaultMaxMessageSizeInUdp)
+                                                  int maxMessageSizeInUdp = GraylogSinkOptionsBase.DefaultMaxMessageSizeInUdp,
+                                                  string host = GraylogSinkOptionsBase.DefaultHost)
         {
             // ReSharper disable once UseObjectOrCollectionInitializer
             var options = new GraylogSinkOptions();
@@ -60,6 +62,7 @@ namespace Serilog.Sinks.Graylog
             options.StackTraceDepth = stackTraceDepth;
             options.Facility = facility.Expand();
             options.MaxMessageSizeInUdp = maxMessageSizeInUdp;
+            options.Host = host;
 
             return loggerSinkConfiguration.Graylog(options);
         }


### PR DESCRIPTION
Added the capability to set output GELF messages' "host" property from within the configuration. If "host" is not specified in the configuration, then the original functionality (DNS hostname) is used.