### PR TITLE
Use UriBuilder to construct urls for HttpTransport to enable obscure scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/.vs/serilog-sinks-graylogvs2017/v15/Server/sqlite3/db.lock
 src/.vs/serilog-sinks-graylogvs2017/DesignTimeBuild/.dtbcache
 /.vs/slnx.sqlite
 .ionide/symbolCache.db
+src/.idea/

--- a/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
@@ -87,7 +87,7 @@ namespace Serilog.Sinks.Graylog.Core
         /// <value>
         /// The port.
         /// </value>
-        public int Port { get; set; }
+        public int? Port { get; set; }
 
         /// <summary>
         /// Gets or sets the transport.

--- a/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
@@ -65,7 +65,7 @@ namespace Serilog.Sinks.Graylog.Core
                 case SinkTransportType.Http: {
                     var builder = new UriBuilder {
                         Host = _options.HostnameOrAddress,
-                        Port = _options.Port ?? -1,
+                        Port = _options.Port.GetValueOrDefault(12201),
                         Path = "gelf"
                     };
                     

--- a/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
@@ -63,8 +63,7 @@ namespace Serilog.Sinks.Graylog.Core
                     return udpTransport;
                 }
                 case SinkTransportType.Http: {
-                    var builder = new UriBuilder {
-                        Host = _options.HostnameOrAddress,
+                    var builder = new UriBuilder(_options.HostnameOrAddress) {
                         Port = _options.Port.GetValueOrDefault(12201),
                         Path = "gelf"
                     };

--- a/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
@@ -51,7 +51,7 @@ namespace Serilog.Sinks.Graylog.Core
                 case SinkTransportType.Udp:
                 {
                     var ipAddress = Task.Run(() => GetIpAddress(_options.HostnameOrAddress)).GetAwaiter().GetResult();
-                    var ipEndpoint = new IPEndPoint(ipAddress ?? throw new InvalidOperationException(), _options.Port);
+                    var ipEndpoint = new IPEndPoint(ipAddress ?? throw new InvalidOperationException(), _options.Port.GetValueOrDefault(12201));
 
 
                     var chunkSettings = new ChunkSettings(_options.MessageGeneratorType, _options.MaxMessageSizeInUdp);
@@ -62,9 +62,14 @@ namespace Serilog.Sinks.Graylog.Core
                     var udpTransport = new UdpTransport(udpClient, chunkConverter);
                     return udpTransport;
                 }
-                case SinkTransportType.Http:
-                {
-                    var httpClient = new HttpTransportClient($"{_options.HostnameOrAddress}:{_options.Port}/gelf");
+                case SinkTransportType.Http: {
+                    var builder = new UriBuilder {
+                        Host = _options.HostnameOrAddress,
+                        Port = _options.Port ?? -1,
+                        Path = "gelf"
+                    };
+                    
+                    var httpClient = new HttpTransportClient(builder.Uri.ToString());
 
                     var httpTransport = new HttpTransport(httpClient);
                     return httpTransport;
@@ -72,7 +77,7 @@ namespace Serilog.Sinks.Graylog.Core
                 case SinkTransportType.Tcp:
                 {
                     var ipAddress = Task.Run(() => GetIpAddress(_options.HostnameOrAddress)).GetAwaiter().GetResult();
-                    var tcpClient = new TcpTransportClient(ipAddress, _options.Port);
+                    var tcpClient = new TcpTransportClient(ipAddress, _options.Port.GetValueOrDefault(12201));
                     var transport = new TcpTransport(tcpClient);
                     return transport;
                 }


### PR DESCRIPTION
This pull request enables scenarios where the /gelf endpoint is not hosted under the normal `HOST:PORT/gelf` path, but instead `HOST:PORT/some-other-url/gelf`

The earlier solution would generate urls like this:
`http://HOST/some-other-url/:12201/gelf`

I introduced these features:

Leaving  `GraylogSinkOptions.Port` set to null (default value) will in the scenario above result in a url that looks like this:
`http://HOST:12201/some-other-url/gelf ` (Port defaults to 12201)

Using the UriBuilder to build the urls also enables us to set the `GraylogSinkOptions.HostnameOrAddress` to something like `http://HOST/some-other-url` and `GraylogSinkOptions.Port ` to -1

Which will then result in an url that looks like this:
`http://HOST/some-other-url/gelf`

This is possible since setting the port to -1 uses the default port for the uri scheme in `HostnameOrAddress`.
