### PR TITLE
Remove references to the `System.Net.NameResolution` package.

### DIFF
--- a/src/Serilog.Sinks.Graylog.Batching/Serilog.Sinks.Graylog.Batching.csproj
+++ b/src/Serilog.Sinks.Graylog.Batching/Serilog.Sinks.Graylog.Batching.csproj
@@ -49,10 +49,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Serilog.Sinks.Graylog.Core\Serilog.Sinks.Graylog.Core.csproj" PrivateAssets="all" />
   </ItemGroup>
-
-  <ItemGroup Condition="('$(TargetFramework)'=='netstandard2.1') Or ('$(TargetFramework)'=='netstandard2.0')">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.*" />
-  </ItemGroup>
   
   <ItemGroup Condition="('$(TargetFramework)'=='net45') Or ('$(TargetFramework)'=='net46') Or ('$(TargetFramework)'=='net461')">
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Graylog.Core/Serilog.Sinks.Graylog.Core.csproj
+++ b/src/Serilog.Sinks.Graylog.Core/Serilog.Sinks.Graylog.Core.csproj
@@ -18,9 +18,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetFramework)'=='netstandard2.1') Or ('$(TargetFramework)'=='netstandard2.0')">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.*" />
-  </ItemGroup>
 
   <ItemGroup Condition="('$(TargetFramework)'=='net45') Or ('$(TargetFramework)'=='net46') Or ('$(TargetFramework)'=='net461')">
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
+++ b/src/Serilog.Sinks.Graylog/Serilog.Sinks.Graylog.csproj
@@ -45,9 +45,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.8.0" />
   </ItemGroup>
-  <ItemGroup Condition="('$(TargetFramework)'=='netstandard2.1') Or ('$(TargetFramework)'=='netstandard2.0')">
-    <PackageReference Include="System.Net.NameResolution" Version="4.3.*" />
-  </ItemGroup>
   
   <ItemGroup Condition="('$(TargetFramework)'=='net45') Or ('$(TargetFramework)'=='net46') Or ('$(TargetFramework)'=='net461')">
     <Reference Include="System" />


### PR DESCRIPTION
It is not needed for .NET Standard 2.x and clutters the dependency tree of the library and all its dependents.