### PR TITLE
Added usernameInHttp and passwordInHttp to options for basic authentication. And implemented.

### DIFF
--- a/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
+++ b/src/Serilog.Sinks.Graylog.Core/GraylogSinkOptions.cs
@@ -168,5 +168,15 @@ namespace Serilog.Sinks.Graylog.Core
         public bool UseSsl { get; set; }
 
         public JsonSerializerSettings SerializerSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username in http
+        /// </summary>
+        public string UsernameInHttp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password in http
+        /// </summary>
+        public string PasswordInHttp { get; set; }
     }
 }

--- a/src/Serilog.Sinks.Graylog.Core/Helpers/HttpBasicAuthenticationGenerator.cs
+++ b/src/Serilog.Sinks.Graylog.Core/Helpers/HttpBasicAuthenticationGenerator.cs
@@ -1,0 +1,43 @@
+﻿using Serilog.Debugging;
+using System;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Serilog.Sinks.Graylog.Core.Helpers
+{
+    public class HttpBasicAuthenticationGenerator
+    {
+        private readonly string _usernameInHttp;
+        private readonly string _passwordInHttp;
+        public HttpBasicAuthenticationGenerator(string usernameInHttp, string passwordInHttp)
+        {
+            _usernameInHttp = usernameInHttp;
+            _passwordInHttp = passwordInHttp;
+        }
+
+        public AuthenticationHeaderValue Generate()
+        {
+            if (!Validate()) return null;
+
+            var byteArray = Encoding.ASCII.GetBytes(string.Concat(_usernameInHttp, ":", _passwordInHttp));
+            return new AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+        }
+
+        private bool Validate()
+        {
+            if (_usernameInHttp == null && _passwordInHttp == null) return false;
+
+            if (_passwordInHttp == null)
+            {
+                SelfLog.WriteLine("UsernameInHttp has value, but passwordInHttp is empty. Therefore basic authentication not used");
+                return false;
+            }
+            if (_usernameInHttp == null)
+            {
+                SelfLog.WriteLine("PasswordInHttp has value, but UsernameInHttp is empty. Therefore basic authentication not used");
+                return false;
+            }
+            return true;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Graylog.Core/Transport/Http/HttpTransportClient.cs
+++ b/src/Serilog.Sinks.Graylog.Core/Transport/Http/HttpTransportClient.cs
@@ -11,12 +11,15 @@ namespace Serilog.Sinks.Graylog.Core.Transport.Http
         private readonly string _graylogUrl;
         private readonly HttpClient _httpClient;
 
-        public HttpTransportClient(string graylogUrl)
+        public HttpTransportClient(string graylogUrl, AuthenticationHeaderValue authorization = null)
         {
             _graylogUrl = graylogUrl;
             _httpClient = new HttpClient();
             _httpClient.DefaultRequestHeaders.ExpectContinue = false;
             _httpClient.DefaultRequestHeaders.CacheControl = new CacheControlHeaderValue { NoCache = true };
+
+            if (authorization != null)
+                _httpClient.DefaultRequestHeaders.Authorization = authorization;
         }
 
         public async Task Send(string message)

--- a/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
@@ -67,8 +67,8 @@ namespace Serilog.Sinks.Graylog.Core
                         Port = _options.Port.GetValueOrDefault(12201),
                         Path = "gelf"
                     };
-                    
-                    var httpClient = new HttpTransportClient(builder.Uri.ToString());
+
+                    var httpClient = new HttpTransportClient(builder.Uri.ToString(), new HttpBasicAuthenticationGenerator(_options.UsernameInHttp, _options.PasswordInHttp).Generate());
 
                     var httpTransport = new HttpTransport(httpClient);
                     return httpTransport;

--- a/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
@@ -170,6 +170,34 @@ namespace Serilog.Sinks.Graylog.Tests
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void LogInformationWithUsernamePassword()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Clear();
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior(1));
+            var profile = fixture.Create<Profile>();
+
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig.WriteTo.Graylog(new GraylogSinkOptions
+            {
+                MinimumLogEventLevel = LogEventLevel.Information,
+                MessageGeneratorType = MessageIdGeneratorType.Timestamp,
+                TransportType = TransportType.Http,
+                Facility = "VolkovTestFacility",
+                HostnameOrAddress = "http://logs.aeroclub.int",
+                Port = 12201,
+                UsernameInHttp ="username",
+                PasswordInHttp ="password"
+            });
+
+            var logger = loggerConfig.CreateLogger();
+
+            logger.Information("battle profile:  {@BattleProfile}", profile);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void TestException()
         {
             var loggerConfig = new LoggerConfiguration();

--- a/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
+++ b/src/Serilog.Sinks.Graylog/LoggerConfigurationGrayLogExtensions.cs
@@ -40,6 +40,8 @@ namespace Serilog.Sinks.Graylog
         /// <param name="host">The host property to use in GELF message. If null, DNS hostname will be used instead.</param>
         /// <param name="includeMessageTemplate">if set to <c>true</c> if include message template to graylog.</param>
         /// <param name="messageTemplateFieldName">Name of the message template field.</param>
+        /// <param name="usernameInHttp">The usernameInHttp. Basic authentication property.</param>
+        /// <param name="passwordInHttp">The passwordInHttp. Basic authentication property.</param>
         /// <returns></returns>
         public static LoggerConfiguration Graylog(this LoggerSinkConfiguration loggerSinkConfiguration,
                                                   string hostnameOrAddress,
@@ -53,7 +55,9 @@ namespace Serilog.Sinks.Graylog
                                                   int maxMessageSizeInUdp = GraylogSinkOptionsBase.DefaultMaxMessageSizeInUdp,
                                                   string host = GraylogSinkOptionsBase.DefaultHost,
                                                   bool includeMessageTemplate = false,
-                                                  string messageTemplateFieldName = GraylogSinkOptionsBase.DefaultMessageTemplateFieldName
+                                                  string messageTemplateFieldName = GraylogSinkOptionsBase.DefaultMessageTemplateFieldName,
+                                                  string usernameInHttp = null,
+                                                  string passwordInHttp = null
                                                   )
         {
             // ReSharper disable once UseObjectOrCollectionInitializer
@@ -70,6 +74,8 @@ namespace Serilog.Sinks.Graylog
             options.Host = host;
             options.IncludeMessageTemplate = includeMessageTemplate;
             options.MessageTemplateFieldName = messageTemplateFieldName;
+            options.UsernameInHttp = usernameInHttp;
+            options.PasswordInHttp = passwordInHttp;
             return loggerSinkConfiguration.Graylog(options);
         }
     }


### PR DESCRIPTION
This pull request enables transport type is http. 
If **usernameInHttp** and **passwordInHttp** options are used, the basic authentication will be available.
