### PR TITLE
Add support for path using in hostnameOrAddress

### DIFF
--- a/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
+++ b/src/Serilog.Sinks.Graylog.Tests/IntegrateSinkTestWithHttp.cs
@@ -198,6 +198,84 @@ namespace Serilog.Sinks.Graylog.Tests
 
         [Fact]
         [Trait("Category", "Integration")]
+        public void LogInformationWithHostnameOrAddressEndsWithoutPath()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Clear();
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior(1));
+            var profile = fixture.Create<Profile>();
+
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig.WriteTo.Graylog(new GraylogSinkOptions
+            {
+                MinimumLogEventLevel = LogEventLevel.Information,
+                MessageGeneratorType = MessageIdGeneratorType.Timestamp,
+                TransportType = TransportType.Http,
+                Facility = "VolkovTestFacility",
+                HostnameOrAddress = "http://logs.aeroclub.int",
+                Port = 12201
+            });
+
+            var logger = loggerConfig.CreateLogger();
+
+            logger.Information("battle profile:  {@BattleProfile}", profile);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void LogInformationWithHostnameOrAddressEndsWithSlash()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Clear();
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior(1));
+            var profile = fixture.Create<Profile>();
+
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig.WriteTo.Graylog(new GraylogSinkOptions
+            {
+                MinimumLogEventLevel = LogEventLevel.Information,
+                MessageGeneratorType = MessageIdGeneratorType.Timestamp,
+                TransportType = TransportType.Http,
+                Facility = "VolkovTestFacility",
+                HostnameOrAddress = "http://logs.aeroclub.int/",
+                Port = 12201
+            });
+
+            var logger = loggerConfig.CreateLogger();
+
+            logger.Information("battle profile:  {@BattleProfile}", profile);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
+        public void LogInformationWithHostnameOrAddressEndsWithPath()
+        {
+            var fixture = new Fixture();
+            fixture.Behaviors.Clear();
+            fixture.Behaviors.Add(new OmitOnRecursionBehavior(1));
+            var profile = fixture.Create<Profile>();
+
+            var loggerConfig = new LoggerConfiguration();
+
+            loggerConfig.WriteTo.Graylog(new GraylogSinkOptions
+            {
+                MinimumLogEventLevel = LogEventLevel.Information,
+                MessageGeneratorType = MessageIdGeneratorType.Timestamp,
+                TransportType = TransportType.Http,
+                Facility = "VolkovTestFacility",
+                HostnameOrAddress = "http://logs.aeroclub.int/testgelf",
+                Port = 12201
+            });
+
+            var logger = loggerConfig.CreateLogger();
+
+            logger.Information("battle profile:  {@BattleProfile}", profile);
+        }
+
+        [Fact]
+        [Trait("Category", "Integration")]
         public void TestException()
         {
             var loggerConfig = new LoggerConfiguration();


### PR DESCRIPTION
path in hostnameOrAddress unusable. For example hostnameOrAddress is http://logs.aeroclub.int/testgelf,

httpClient creating with "http://logs.aeroclub.int/gelf".  "gelf" is const in code. So "testgelf" not usable.

With this pr httpClient will be create with "http://logs.aeroclub.int/testgelf". 
If when I dont use path, or hostnameOrAddress endswith "/" chracter, httpClient will be create with "http://logs.aeroclub.int/gelf". 

Now, is hostnameOrAddress
"http://logs.aeroclub.int" httpClient will be create with  "http://logs.aeroclub.int/gelf"
"http://logs.aeroclub.int/" httpClient will be create with  "http://logs.aeroclub.int/gelf"
"http://logs.aeroclub.int/testgelf" httpClient will be create with  "http://logs.aeroclub.int/testgelf"