### PR TITLE
Add https support to http transport type.

### DIFF
--- a/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
+++ b/src/Serilog.Sinks.Graylog.Core/TransportFactory.cs
@@ -66,7 +66,7 @@ namespace Serilog.Sinks.Graylog.Core
                 }
                 case SinkTransportType.Http: 
                 {
-                    var builder = GetUriBuilder(_options.HostnameOrAddress);
+                    var builder = GetUriBuilder(_options.HostnameOrAddress, _options.UseSsl);
                     var httpClient = new HttpTransportClient(builder.Uri.ToString(), new HttpBasicAuthenticationGenerator(_options.UsernameInHttp, _options.PasswordInHttp).Generate());
 
                     var httpTransport = new HttpTransport(httpClient);
@@ -93,11 +93,12 @@ namespace Serilog.Sinks.Graylog.Core
             return ipAddress;
         }
 
-        private UriBuilder GetUriBuilder(string hostnameOrAddress)
+        private UriBuilder GetUriBuilder(string hostnameOrAddress, bool useSsl)
         {
             var builder = new UriBuilder(hostnameOrAddress)
             {
-                Port = _options.Port.GetValueOrDefault(443)
+                Port = _options.Port.GetValueOrDefault(443),
+                Scheme = useSsl ? "https" : "http"
             };
 
             if (builder.Path == _emptyHttpUriPath)


### PR DESCRIPTION
When using the http transport type to log to an instance of Graylog that uses SSL, the TransportFactory creates an UriBuilder using the default http scheme, even when UseSsl is set to true. This pull request adds support for the https scheme when using the http transport type.